### PR TITLE
fix(hero): typo in TypeScript

### DIFF
--- a/src/components/HomepageSections/Hero.tsx
+++ b/src/components/HomepageSections/Hero.tsx
@@ -75,7 +75,7 @@ export const Hero = ({ categoriesCount, templatesCount }: HeroProps) => {
               <Stack spacing={4}>
                 <Feature>Responsive Demos</Feature>
                 <Feature>Easy Customizable</Feature>
-                <Feature>Written in Typescript</Feature>
+                <Feature>Written in TypeScript</Feature>
               </Stack>
               <Stack spacing={4}>
                 <Feature>100% Open Source</Feature>


### PR DESCRIPTION
Currently, the homepage Hero has the feature as - "Written in Typescript", whereas it should be "Written in TypeScript" (ref: https://www.typescriptlang.org/).